### PR TITLE
Add support for Android 13

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "moe.henry_zhr.kill_domain_verification"
         minSdk 23
-        targetSdk 32
+        targetSdk 33
         versionCode 2
         versionName "2"
     }

--- a/app/src/main/java/moe/henry_zhr/kill_domain_verification/MainHook.java
+++ b/app/src/main/java/moe/henry_zhr/kill_domain_verification/MainHook.java
@@ -23,11 +23,27 @@ public class MainHook implements IXposedHookLoadPackage {
 
     XposedBridge.log(String.format("[%s] Starting hook", TAG));
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      XposedBridge.log(String.format("[%s] Android 12 or above detected", TAG));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      XposedBridge.log(String.format("[%s] Android 13 or above detected", TAG));
 
-      // used in frameworks/base/services/core/java/com/android/server/pm/PackageManagerService.java filterCandidatesWithDomainPreferredActivitiesLPrBody
-      // (cs.android.com failed to get the commit so there isn't a link)
+      // https://cs.android.com/android/platform/superproject/+/android-13.0.0_r3:frameworks/base/services/core/java/com/android/server/pm/ComputerEngine.java;l=1058
+      XposedHelpers.findAndHookMethod(
+          "com.android.server.pm.verify.domain.DomainVerificationUtils",
+          lpparam.classLoader,
+          "isDomainVerificationIntent",
+          Intent.class,
+          long.class,
+          new XC_MethodReplacement() {
+            @Override
+            protected Object replaceHookedMethod(MethodHookParam param) {
+              return false;
+            }
+          }
+      );
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      XposedBridge.log(String.format("[%s] Android 12 detected", TAG));
+
+      // https://cs.android.com/android/platform/superproject/+/android-12.0.0_r34:frameworks/base/services/core/java/com/android/server/pm/PackageManagerService.java;l=2788
       XposedHelpers.findAndHookMethod(
           "com.android.server.pm.verify.domain.DomainVerificationUtils",
           lpparam.classLoader,

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Dec 05 14:59:25 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Android 13, at least in AOSP and the Pixel firmware, still uses `DomainVerificationUtils.isDomainVerificationIntent()`, but the `flags` field is now a long instead of an int.

This PR also updates the gradle wrapper and Android Gradle plugin so that the project can target API 33.